### PR TITLE
feat: implement negative caching to prevent DB hits for invalid shortcode

### DIFF
--- a/src/main/java/com/rapidlink/services/UrlCacheService.java
+++ b/src/main/java/com/rapidlink/services/UrlCacheService.java
@@ -12,4 +12,8 @@ public interface UrlCacheService {
     void save(String shortCode, String originalUrl, Duration ttl);
 
     void delete(String shortCode);
+
+    boolean isNotFoundSentinel(String cachedValue);
+
+    void saveNotFound(String shortCode);
 }

--- a/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
+++ b/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
@@ -82,6 +82,13 @@ public class ShortUrlServiceImpl implements ShortUrlService {
         Optional<String> cached = cacheService.get(shortCode);
         if (cached.isPresent()) {
 
+            // Negative cache HIT — this code was confirmed non-existent.
+            // Skip DB entirely and return 404 immediately.
+            if (cacheService.isNotFoundSentinel(cached.get())) {
+                log.info("Negative cache HIT — shortCode={}, returning 404 without DB query", shortCode);
+                throw new ShortUrlNotFoundException("Short URL not found, with this shortcode: " + shortCode);
+            }
+
             log.info("Cache HIT — shortCode={}", shortCode);
             return resolveFromCacheOrFallback(shortCode, cached.get());
         }
@@ -105,7 +112,7 @@ public class ShortUrlServiceImpl implements ShortUrlService {
                 new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
-                        cacheService.save(shortCode, url);
+                        cacheService.save(shortCode, url); // warm with real URL
                     }
                 }
         );
@@ -145,8 +152,20 @@ public class ShortUrlServiceImpl implements ShortUrlService {
      */
     private URI resolveFromDatabase(String shortCode){
 
-        // Fetches by shortCode and validates active/expiry state in one step
-        ShortUrl url = findAndValidate(shortCode);
+        // findAndValidate throws ShortUrlNotFoundException if the code doesn't exist.
+        // We intercept that specific case to write the negative sentinel BEFORE rethrowing.
+        ShortUrl url;
+
+        try {
+            url = findAndValidate(shortCode);
+        } catch (ShortUrlNotFoundException ex) {
+
+            // DB confirmed: this short code does not exist.
+            // Cache the negative result so future requests skip the DB entirely.
+            cacheService.saveNotFound(shortCode);
+            log.info("Negative cache written — shortCode={}", shortCode);
+            throw ex; // rethrow — caller (resolveUrl) handles the 404 response
+        }
 
         // Build URI FIRST (avoid caching invalid URL)
         URI uri = parseUri(url.getOriginalUrl(), shortCode);

--- a/src/main/java/com/rapidlink/services/impl/UrlCacheServiceImpl.java
+++ b/src/main/java/com/rapidlink/services/impl/UrlCacheServiceImpl.java
@@ -18,7 +18,9 @@ public class UrlCacheServiceImpl implements UrlCacheService {
     private final StringRedisTemplate redisTemplate;
 
     private static final String PREFIX = "url:";
+    private static final String NOT_FOUND_SENTINEL = "__NOT_FOUND__";
     private static final Duration DEFAULT_TTL = Duration.ofHours(24);
+    private static final Duration NEGATIVE_CACHE_TTL = Duration.ofSeconds(60);
 
     // Fetch original URL from Redis cache
     @Override
@@ -113,6 +115,39 @@ public class UrlCacheServiceImpl implements UrlCacheService {
             log.error("Unexpected Redis error during delete — key={}", key, ex);
         }
     }
+
+    /**
+     * Caches the fact that this shortCode does not exist in the DB.
+     * Uses a short TTL to limit staleness risk if the code is later created.
+     */
+    @Override
+    public void saveNotFound(String shortCode) {
+        if (shortCode == null || shortCode.isBlank()) {
+            log.warn("Skipping negative cache write — shortCode is blank");
+            return;
+        }
+        String key = buildKey(shortCode);
+        try {
+            redisTemplate.opsForValue().set(key, NOT_FOUND_SENTINEL, NEGATIVE_CACHE_TTL);
+            log.debug("Negative cache entry written — shortCode={}, TTL={}m",
+                    shortCode, NEGATIVE_CACHE_TTL.toMinutes());
+        } catch (RedisConnectionFailureException ex) {
+            log.warn("Redis unavailable — skipping negative cache write — key={}", key);
+        } catch (RuntimeException ex) {
+            log.error("Unexpected Redis error during saveNotFound — key={}", key, ex);
+        }
+    }
+
+    /**
+     * Returns true if the cached value is a negative sentinel (i.e., "not found" was cached).
+     * Callers should check this BEFORE treating the Optional value as a real URL.
+     */
+    @Override
+    public boolean isNotFoundSentinel(String cachedValue) {
+        return NOT_FOUND_SENTINEL.equals(cachedValue);
+    }
+
+    // ---------- Helper Methods --------
 
     // Build Redis key with namespace
     private String buildKey(String shortCode) {


### PR DESCRIPTION
## Overview

This PR introduces negative caching for short URL resolution to prevent repeated database queries for non-existent shortcodes.

When a shortcode is not found in the database, a sentinel value is cached in Redis for a short duration. Subsequent requests for the same invalid shortcode are served directly from cache, avoiding unnecessary DB round-trips.

## Changes Introduced
1. Negative Cache Support

- Added sentinel value (`__NOT_FOUND__`) to represent non-existent shortcodes
- Implemented `saveNotFound()` in cache service
- Added `isNotFoundSentinel()` helper for detection

2. Resolve Flow Enhancement
```
On cache hit:
If sentinel → return 404 without DB call
On DB miss:
Cache negative result with short TTL
```
3. Cache Consistency Fix

- On shortcode creation:
- Overwrites any existing negative cache entry to prevent stale 404 responses

4. TTL Strategy

- Positive cache → long TTL (existing behavior)
- Negative cache → short TTL to avoid stale data

## Testing
- Verified:

  - Cache hit (valid shortcode)
  - Cache hit (negative sentinel)
  - Cache miss → DB lookup → negative cache write
  - Overwrite of negative cache on new shortcode creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added negative caching support to improve performance by caching non-existent short codes for 60 seconds, eliminating redundant database lookups for the same invalid codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->