### PR TITLE
Set-Up Observability Stack (Micrometer + Prometheus + Grafana)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,6 +14,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - rapidlink-network
+
   redis:
     image: redis:7
     container_name: rapidlink-redis
@@ -23,8 +24,37 @@ services:
     networks:
       - rapidlink-network
 
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    container_name: rapidlink-prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - rapidlink-network
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: rapidlink-grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - rapidlink-network
+
+
 volumes:
   postgres_data:
+  grafana_data:
 
 networks:
   rapidlink-network:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,18 @@
+
+global:
+  # Prometheus will collect metrics every 5 seconds
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'rapidlink-app'
+
+    metrics_path: '/actuator/prometheus'
+    # Endpoint from which Prometheus pulls metrics (exposed by Spring Boot Actuator)
+
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        # Target application to scrape metrics from
+        # host.docker.internal = access localhost app from inside Docker
+
+    scrape_timeout: 4s
+    # Max time Prometheus waits for a response before timing out

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
+        <!-- Actuator (required for metrics exposure) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Prometheus registry -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,45 @@ server:
 logging:
   level:
     org.hibernate.SQL: DEBUG
+
+
+# ── Actuator & Metrics ──────────────────────────────────────────────
+management:
+  # Expose monitoring endpoints over HTTP
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+
+  # Enables /actuator/prometheus endpoint
+  endpoint:
+    prometheus:
+      enabled: true
+
+    # Shows detailed health info (DB, Redis, etc.)
+    health:
+      show-details: always
+
+  # Adds "application=rapidlink" label to all metrics (useful in Grafana filtering)
+  metrics:
+    tags:
+      application: rapidlink
+    enable:
+      lettuce: true
+
+    # Enables latency histogram (required for accurate p95/p99 in Prometheus)
+    distribution:
+      percentiles-histogram:
+        http:
+          server:
+            requests: true
+
+      percentiles:
+        http:
+          server:
+            requests: 0.5, 0.95, 0.99
+            # Calculates latency percentiles:
+            # p50 → median
+            # p95 → slow users
+            # p99 → worst-case latency
+


### PR DESCRIPTION

## Overview

This PR introduces a basic observability setup for RapidLink using Micrometer, Prometheus, and Grafana. It enables collection, exposure, and visualization of application metrics for monitoring system health and performance.

---

### Changes Made

#### 1. Application Instrumentation

* Added Spring Boot Actuator dependency
* Added Micrometer Prometheus registry dependency
* Exposed `/actuator/prometheus` endpoint
* Updated `application.yml` for metrics and actuator configuration

#### 2. Monitoring Stack (Docker Compose)

* Added Prometheus service
* Added Grafana service
* Configured services in `compose.yml`

#### 3. Prometheus Configuration

* Added `monitoring/prometheus.yml`
* Configured scraping for RapidLink metrics endpoint

---

### What This Enables

* JVM and system metrics collection
* HTTP request metrics via Spring Boot Actuator
* Prometheus scraping metrics from the application
* Grafana dashboards for visualization

---

### Next Steps

* Add custom business metrics (redirect count, latency, cache hit/miss)
* Build a dedicated RapidLink Grafana dashboard
* Add alerting rules for critical metrics

---

### Impact

* No breaking changes
* Adds monitoring capability without affecting existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Prometheus and Grafana monitoring stack for comprehensive application observability
  * Application now exposes detailed health checks, performance metrics, and system information endpoints
  * Enables real-time collection, visualization, and analysis of application performance and infrastructure metrics
  * Provides enhanced monitoring capabilities for tracking application health, response times, and resource utilization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->