### PR TITLE
Add Custom RapidLink Business Metrics

### DIFF
--- a/src/main/java/com/rapidlink/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/rapidlink/exception/GlobalExceptionHandler.java
@@ -1,8 +1,13 @@
 package com.rapidlink.exception;
 
 import com.rapidlink.dto.response.ErrorResponse;
+import com.rapidlink.metrics.RapidLinkMetrics;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.RedisSystemException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,8 +23,11 @@ import java.util.stream.Collectors;
  * Converts exceptions into a consistent API error response.
  */
 @RestControllerAdvice
+@RequiredArgsConstructor
 @Slf4j
 public class GlobalExceptionHandler {
+
+    private final RapidLinkMetrics metrics;
 
     /**
      * Handles all custom exceptions (business logic errors).
@@ -79,6 +87,50 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handles Spring Data / JDBC exceptions from PostgreSQL.
+     */
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<ErrorResponse> handleDataAccessException(
+            DataAccessException ex,
+            HttpServletRequest req
+    ) {
+        metrics.recordError("db_error");
+        log.error("Database error at path={}", req.getRequestURI(), ex);
+
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                "Something went wrong",
+                req.getRequestURI()
+        );
+
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Handles Redis connection failures specifically.
+     */
+    @ExceptionHandler({RedisConnectionFailureException.class, RedisSystemException.class})
+    public ResponseEntity<ErrorResponse> handleRedisException(
+            RuntimeException ex,
+            HttpServletRequest req
+    ) {
+        metrics.recordError("redis_unavailable");
+        log.error("Redis error at path={}", req.getRequestURI(), ex);
+
+        ErrorResponse response = new ErrorResponse(
+                LocalDateTime.now(),
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                "Something went wrong",
+                req.getRequestURI()
+        );
+
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
      * Handles unexpected errors (fallback).
      * We don’t expose internal details to the user.
      */
@@ -87,6 +139,9 @@ public class GlobalExceptionHandler {
             Exception ex,
             HttpServletRequest req
     ) {
+
+        metrics.recordError("unexpected");
+
         // Log full error for debugging
         log.error("Unexpected error occurred at path={}", req.getRequestURI(), ex);
 

--- a/src/main/java/com/rapidlink/metrics/RapidLinkMetrics.java
+++ b/src/main/java/com/rapidlink/metrics/RapidLinkMetrics.java
@@ -1,0 +1,225 @@
+package com.rapidlink.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Central metrics component for RapidLink.
+ *
+ * This class is responsible for:
+ * - Defining and registering all application metrics (Counters, Timers, Gauges)
+ * - Providing a simple API for the service layer to record events
+ *
+ * Design principles:
+ * - Metrics are created once at startup (@PostConstruct)
+ * - No business logic lives here (only recording signals)
+ * - Lightweight methods to avoid impacting request performance
+ *
+ * All metrics are exposed via Micrometer and scraped by Prometheus.
+ */
+
+@Component
+@RequiredArgsConstructor
+public class RapidLinkMetrics {
+
+    /*
+     * Central registry where all metrics are stored.
+     * Prometheus reads metrics from here via /actuator/prometheus.
+     */
+    private final MeterRegistry registry;
+
+    // ── Counters (event tracking) ────────────────────────────────────────────
+    // Counters only increase; used for rates in Prometheus
+
+    private Counter cacheHitCounter;
+    private Counter cacheMissCounter;
+    private Counter negativeCacheHitCounter;
+
+    private Counter urlCreateSuccessCounter;
+    private Counter urlCreateFailureCounter;
+
+    private Counter redirectSuccessCounter;
+    private Counter redirectNotFoundCounter;
+    private Counter redirectExpiredCounter;
+
+    private Counter clickIncrementCounter;
+    private Counter clickFlushToDbCounter;
+
+    // ── Timers (latency tracking) ────────────────────────────────────────────
+    // Automatically tracks count, total time, and percentiles
+
+    private Timer redirectLatencyTimer;
+    private Timer urlCreateLatencyTimer;
+
+    // ── Gauge (current state) ────────────────────────────────────────────────
+    // Holds latest value; read during Prometheus scrape
+
+    private final AtomicLong activeUrlCount = new AtomicLong(0);
+
+    // ── Registration ──────────────────────────────────────────────────────────
+
+    /*
+     * @PostConstruct runs once after Spring injects all dependencies.
+     * This is the right place to register metrics because:
+     * - MeterRegistry is fully initialized by this point
+     * - Metrics are registered once and reused (not recreated per request)
+     * - Bcz, Recreating a Counter on every request would throw an exception
+     */
+
+    @PostConstruct
+    public void registerMetrics() {
+
+        // ── Cache counters ────────────────────────────────────────────────────
+
+        /*
+         * Metric naming uses dot notation.
+         * Micrometer converts it to Prometheus format automatically.
+         * Example: rapidlink.cache.hit → rapidlink_cache_hit_total
+         */
+
+        cacheHitCounter = Counter.builder("rapidlink.cache.hit")
+                .description("Short URL was found in Redis — no DB query needed")
+                .register(registry);
+
+        cacheMissCounter = Counter.builder("rapidlink.cache.miss")
+                .description("Short URL was not in Redis — DB fallback executed")
+                .register(registry);
+
+        negativeCacheHitCounter = Counter.builder("rapidlink.cache.negative.hit")
+                .description("Redis held a sentinel value confirming short code does not exist — DB query skipped")
+                .register(registry);
+
+        // ── URL creation and Redirect counters ─────────────────────────────────────────
+
+        /*
+         * Using separate counters instead of tags for simplicity.
+         * Easier to integrate and query.
+         * Can be refactored to tagged metrics later if needed.
+         */
+
+        urlCreateSuccessCounter = Counter.builder("rapidlink.url.create.success")
+                .description("Short URL created and persisted successfully")
+                .register(registry);
+
+        urlCreateFailureCounter = Counter.builder("rapidlink.url.create.failure")
+                .description("Short URL creation failed — validation error, DB error, or duplicate")
+                .register(registry);
+
+        // Redirect tracking
+        redirectSuccessCounter = Counter.builder("rapidlink.redirect.success")
+                .description("Short URL resolved and redirect returned successfully")
+                .register(registry);
+
+        redirectNotFoundCounter = Counter.builder("rapidlink.redirect.not_found")
+                .description("Short code did not exist in cache or DB")
+                .register(registry);
+
+        redirectExpiredCounter = Counter.builder("rapidlink.redirect.expired")
+                .description("Short URL existed but its expiry time has passed")
+                .register(registry);
+
+        // Click tracking
+        clickIncrementCounter = Counter.builder("rapidlink.click.increment")
+                .description("A click was recorded — either directly to DB (before) or to Redis (after optimization)")
+                .register(registry);
+
+        clickFlushToDbCounter = Counter.builder("rapidlink.click.flush.db")
+                .description("Clicks flushed from Redis to PostgreSQL in a batch write")
+                .register(registry);
+
+
+        // ── Create and Redirect latency timer ────────────────────────────────────────────
+
+        /*
+         * Pre-computes common percentiles (p50, p95, p99)
+         * so they are easier to use in dashboards.
+         */
+
+        urlCreateLatencyTimer = Timer.builder("rapidlink.url.create.latency")
+                .description("Full duration of URL creation: validation → code generation → DB insert → cache write")
+                .publishPercentiles(0.50, 0.95, 0.99)
+                .register(registry);
+
+        redirectLatencyTimer = Timer.builder("rapidlink.redirect.latency")
+                .description("Full duration of short URL resolution: cache check → optional DB query → expiry check")
+                .publishPercentiles(0.50, 0.95, 0.99)
+                .register(registry);
+
+        // ── Active URL gauge ──────────────────────────────────────────────────
+
+        /*
+         * Gauge reads the current value of activeUrlCount during each scrape.
+         * The value is controlled manually via setActiveUrlCount().
+         */
+
+        Gauge.builder("rapidlink.urls.active", activeUrlCount, AtomicLong::get)
+                .description("Current count of non-expired shortened URLs")
+                .register(registry);
+
+    }
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /*
+     * Methods used by the service layer to record metrics.
+     * Each method is intentionally simple (one-liner).
+     * This keeps metrics lightweight and safe to use in critical paths.
+     */
+
+    // Cache
+    public void recordCacheHit()  { cacheHitCounter.increment(); }
+    public void recordCacheMiss() { cacheMissCounter.increment(); }
+    public void recordNegativeCacheHit() { negativeCacheHitCounter.increment(); }
+
+    // URL creation
+    public void recordUrlCreateSuccess() { urlCreateSuccessCounter.increment(); }
+    public void recordUrlCreateFailure() { urlCreateFailureCounter.increment(); }
+
+    // Redirect outcomes
+    public void recordRedirectSuccess()  { redirectSuccessCounter.increment(); }
+    public void recordRedirectNotFound() { redirectNotFoundCounter.increment(); }
+    public void recordRedirectExpired()  { redirectExpiredCounter.increment(); }
+
+    // Click tracking
+    public void recordClickIncrement()          { clickIncrementCounter.increment(); }
+    public void recordClickFlushToDb(long count) { clickFlushToDbCounter.increment(count); }
+
+    // Error
+    /*
+     * Records errors with a dynamic "type" tag (e.g., db, redis, validation).
+     * A new metric series is created per type.
+     */
+    public void recordError(String type) {
+        Counter.builder("rapidlink.error")
+                .description("Unexpected system error")
+                .tag("type", type)
+                .register(registry)
+                .increment();
+    }
+
+    // Timer
+    /*
+     * Wraps any operation and records its execution time.
+     * Ensures latency is recorded even if the operation throws an exception.
+     */
+
+    public <T> T timeUrlCreate(Supplier<T> operation) {
+        return urlCreateLatencyTimer.record(operation);
+    }
+
+    public <T> T timeRedirect(Supplier<T> operation) {
+        return redirectLatencyTimer.record(operation);
+    }
+
+    // Gauge
+    // Update active URL count when URLs are created or expired
+    public void setActiveUrlCount(long count) { activeUrlCount.set(count); }
+
+}

--- a/src/main/java/com/rapidlink/repository/ShortUrlRepository.java
+++ b/src/main/java/com/rapidlink/repository/ShortUrlRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -41,4 +42,6 @@ public interface ShortUrlRepository extends JpaRepository<ShortUrl, UUID> {
     @Query("SELECT u FROM ShortUrl u WHERE u.shortCode = :shortCode " +
             "AND u.isActive = true AND (u.expiresAt IS NULL OR u.expiresAt > CURRENT_TIMESTAMP)")
     Optional<ShortUrl> findActiveByShortCode(@Param("shortCode") String shortCode);
+
+    long countByExpiresAtAfterOrExpiresAtIsNull(LocalDateTime now);
 }

--- a/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
+++ b/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
@@ -3,6 +3,7 @@ package com.rapidlink.services.impl;
 import com.rapidlink.encoder.Base62Encoder;
 import com.rapidlink.entity.ShortUrl;
 import com.rapidlink.exception.*;
+import com.rapidlink.metrics.RapidLinkMetrics;
 import com.rapidlink.repository.ShortUrlRepository;
 import com.rapidlink.services.ShortUrlService;
 import com.rapidlink.services.UrlCacheService;
@@ -26,6 +27,8 @@ public class ShortUrlServiceImpl implements ShortUrlService {
 
     private final ShortUrlRepository repository;
     private final UrlCacheService cacheService;
+    private final RapidLinkMetrics metrics;
+
     private static final long MIN_CACHE_TTL_SECONDS = 5;
     private static final int MAX_URL_LENGTH = 2048;
 
@@ -34,43 +37,62 @@ public class ShortUrlServiceImpl implements ShortUrlService {
     @Transactional
     public String createShortUrl(String originalUrl) {
 
-        log.info("Creating short URL request received");
+        // timeUrlCreate() wraps the ENTIRE creation flow
+        return metrics.timeUrlCreate(() -> {
 
-        URI validatedUri = validateAndNormalizeUrl(originalUrl);
-        String normalizedUrl = validatedUri.toString();
+            log.info("Creating short URL request received");
 
-        Long seqId = repository.nextSeqId();
-        if (seqId == null) {
-            throw new ShortCodeGenerationException("DB Sequence returned null");
-        }
+            URI validatedUri = validateAndNormalizeUrl(originalUrl);
+            String normalizedUrl = validatedUri.toString();
 
-        // TODO: Current implementation is predictable (seq_id → Base62).
-        // Consider adding obfuscation (e.g., hashing or ID scrambling)
-        // to prevent enumeration attacks in public URLs.
-        String shortCode = Base62Encoder.encode(seqId);
+            Long seqId = repository.nextSeqId();
+            if (seqId == null) {
 
-        ShortUrl url = ShortUrl.builder()
-                .originalUrl(normalizedUrl)
-                .seqId(seqId)
-                .shortCode(shortCode)
-                .isActive(true)
-                .clickCount(0L)
-                .build();
+                // record Url creation failure
+                metrics.recordUrlCreateFailure();
+                throw new ShortCodeGenerationException("DB Sequence returned null");
+            }
 
-        try {
-            // Force immediate DB flush so constraint violations are thrown here
-            // (otherwise exceptions occur at transaction commit, outside this try-catch)
-            repository.saveAndFlush(url);
-        } catch (DataIntegrityViolationException ex) {
-            log.error("DB constraint violation during short URL creation — shortCode={}", shortCode, ex);
-            throw new ShortCodeGenerationException();
-        }
+            // TODO: Current implementation is predictable (seq_id → Base62).
+            // Consider adding obfuscation (e.g., hashing or ID scrambling)
+            // to prevent enumeration attacks in public URLs.
+            String shortCode = Base62Encoder.encode(seqId);
 
-        // Write-through cache warm — fires only AFTER @Transactional commits
-        registerCacheAfterCommit(shortCode, normalizedUrl);
+            ShortUrl url = ShortUrl.builder()
+                    .originalUrl(normalizedUrl)
+                    .seqId(seqId)
+                    .shortCode(shortCode)
+                    .isActive(true)
+                    .clickCount(0L)
+                    .build();
 
-        log.info("Short URL created successfully: shortCode={}", shortCode);
-        return shortCode;
+            try {
+                // Force immediate DB flush so constraint violations are thrown here
+                // (otherwise exceptions occur at transaction commit, outside this try-catch)
+                repository.saveAndFlush(url);
+            } catch (DataIntegrityViolationException ex) {
+
+                // record Url creation failure
+                metrics.recordUrlCreateFailure();
+                log.error("DB constraint violation during short URL creation — shortCode={}", shortCode, ex);
+                throw new ShortCodeGenerationException();
+            }
+
+            // Write-through cache warm — fires only AFTER @Transactional commits
+            registerCacheAfterCommit(shortCode, normalizedUrl);
+
+            // TODO: Update setActiveUrlCount() periodically (scheduler) or maintain counter manually (event-driven)
+            // Update active URL gauge AFTER successful DB save.
+            // This keeps the gauge accurate even if URLs are expired
+            long activeUrlCount = repository.countByExpiresAtAfterOrExpiresAtIsNull(LocalDateTime.now());
+            metrics.setActiveUrlCount(activeUrlCount);
+
+            // Set Url creation success
+            metrics.recordUrlCreateSuccess();
+
+            log.info("Short URL created successfully: shortCode={}", shortCode);
+            return shortCode;
+        });
     }
 
     // Resolves short code with original URL and tracks click
@@ -78,24 +100,41 @@ public class ShortUrlServiceImpl implements ShortUrlService {
     @Transactional // TODO: Temporary for MVP. Replace with Redis-based counter + async persistence to avoid transaction overhead and row-level contention under high traffic.
     public URI resolveUrl(String shortCode) {
 
-        // Cache check
-        Optional<String> cached = cacheService.get(shortCode);
-        if (cached.isPresent()) {
 
-            // Negative cache HIT — this code was confirmed non-existent.
-            // Skip DB entirely and return 404 immediately.
-            if (cacheService.isNotFoundSentinel(cached.get())) {
-                log.info("Negative cache HIT — shortCode={}, returning 404 without DB query", shortCode);
-                throw new ShortUrlNotFoundException("Short URL not found, with this shortcode: " + shortCode);
+        // timeRedirect() wraps the ENTIRE resolution flow.
+        return metrics.timeRedirect(() -> {
+
+            URI result;
+
+            // Cache check
+            Optional<String> cached = cacheService.get(shortCode);
+            if (cached.isPresent()) {
+
+                // Negative cache HIT — this code was confirmed non-existent.
+                // Skip DB entirely and return 404 immediately.
+                if (cacheService.isNotFoundSentinel(cached.get())) {
+                    log.info("Negative cache HIT — shortCode={}, returning 404 without DB query", shortCode);
+                    throw new ShortUrlNotFoundException("Short URL not found, with this shortcode: " + shortCode);
+                }
+
+                log.info("Cache HIT — shortCode={}", shortCode);
+                result = resolveFromCacheOrFallback(shortCode, cached.get());
+            }else {
+
+                //  If cache miss, DB lookup
+                log.info("Cache MISS — shortCode={}, querying DB", shortCode);
+                result = resolveFromDatabase(shortCode);
             }
 
-            log.info("Cache HIT — shortCode={}", shortCode);
-            return resolveFromCacheOrFallback(shortCode, cached.get());
-        }
-
-        //  If cache miss, DB lookup
-        log.info("Cache MISS — shortCode={}, querying DB", shortCode);
-        return resolveFromDatabase(shortCode);
+            /*
+             * Record success and click ONLY after all validation and
+             * click increment succeed. If any step above threw, these
+             * lines are never reached — preventing false success counts.
+             */
+            metrics.recordRedirectSuccess();
+            metrics.recordClickIncrement();
+            return result;
+        });
     }
 
 
@@ -160,11 +199,24 @@ public class ShortUrlServiceImpl implements ShortUrlService {
             url = findAndValidate(shortCode);
         } catch (ShortUrlNotFoundException ex) {
 
-            // DB confirmed: this short code does not exist.
+            // DB confirmed: this short code does not exist. or exits but expired
+            // recordRedirectNotFound() fires here
+            metrics.recordRedirectNotFound();
+
             // Cache the negative result so future requests skip the DB entirely.
             cacheService.saveNotFound(shortCode);
             log.info("Negative cache written — shortCode={}", shortCode);
             throw ex; // rethrow — caller (resolveUrl) handles the 404 response
+        }catch (UrlDeactivatedException ex){
+
+            // URL was manually deactivated. Counted as not_found from the user's perspective
+            metrics.recordRedirectNotFound();
+            throw ex;
+        }catch (UrlExpiredException ex){
+
+            // URL exists in DB but has passed its expiry time.
+            metrics.recordRedirectExpired();
+            throw ex;
         }
 
         // Build URI FIRST (avoid caching invalid URL)
@@ -252,10 +304,12 @@ public class ShortUrlServiceImpl implements ShortUrlService {
 
         // Defensive null/blank check (DTO validation may not always apply)
         if (originalUrl == null || originalUrl.isBlank()) {
+            metrics.recordUrlCreateFailure();
             throw new BadRequestException("URL must not be empty");
         }
 
         if (originalUrl.length() > MAX_URL_LENGTH) {
+            metrics.recordUrlCreateFailure();
             throw new BadRequestException("URL exceeds maximum allowed length");
         }
 
@@ -266,18 +320,22 @@ public class ShortUrlServiceImpl implements ShortUrlService {
             String scheme = uri.getScheme();
             if (scheme == null ||
                     !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+
+                metrics.recordUrlCreateFailure();
                 throw new BadRequestException("Only HTTP/HTTPS URLs are allowed");
             }
 
             // Validate host presence (required for proper redirection)
             String host = uri.getHost();
             if (host == null || host.isBlank()) {
+                metrics.recordUrlCreateFailure();
                 throw new BadRequestException("Invalid URL: host is missing");
             }
 
             return uri;
 
         } catch (IllegalArgumentException ex) {
+            metrics.recordUrlCreateFailure();
             throw new BadRequestException("Invalid URL format");
         }
     }

--- a/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
+++ b/src/main/java/com/rapidlink/services/impl/ShortUrlServiceImpl.java
@@ -113,6 +113,10 @@ public class ShortUrlServiceImpl implements ShortUrlService {
                 // Negative cache HIT — this code was confirmed non-existent.
                 // Skip DB entirely and return 404 immediately.
                 if (cacheService.isNotFoundSentinel(cached.get())) {
+
+                    // Even shortcode exists in negative cache, still count as not found.
+                    metrics.recordRedirectNotFound();
+
                     log.info("Negative cache HIT — shortCode={}, returning 404 without DB query", shortCode);
                     throw new ShortUrlNotFoundException("Short URL not found, with this shortcode: " + shortCode);
                 }

--- a/src/main/java/com/rapidlink/services/impl/UrlCacheServiceImpl.java
+++ b/src/main/java/com/rapidlink/services/impl/UrlCacheServiceImpl.java
@@ -1,5 +1,6 @@
 package com.rapidlink.services.impl;
 
+import com.rapidlink.metrics.RapidLinkMetrics;
 import com.rapidlink.services.UrlCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import java.util.Optional;
 public class UrlCacheServiceImpl implements UrlCacheService {
 
     private final StringRedisTemplate redisTemplate;
+    private final RapidLinkMetrics metrics;
 
     private static final String PREFIX = "url:";
     private static final String NOT_FOUND_SENTINEL = "__NOT_FOUND__";
@@ -37,9 +39,23 @@ public class UrlCacheServiceImpl implements UrlCacheService {
             String value = redisTemplate.opsForValue().get(key);
 
             if (value == null) {
+                //RecordCache miss. bcz Redis has no entry for this key.
+                metrics.recordCacheMiss();
+
                 log.debug("Cache MISS for key: {}", key);
                 return Optional.empty();
             }
+
+            if (isNotFoundSentinel(value)) {
+                //Record negative cache hit. bcz Redis is holding a sentinel value.
+                metrics.recordNegativeCacheHit();
+
+                log.debug("Negative sentinel HIT for key: {}", key);
+                return Optional.of(value);
+            }
+
+            // RecordCache cache hit. bcz Redis has the original URL.
+            metrics.recordCacheHit();
 
             log.debug("Cache HIT cache service for key: {}", key);
             return Optional.of(value);


### PR DESCRIPTION
###  Overview

This PR introduces **custom business-level metrics** for RapidLink using Micrometer, extending the existing observability setup (Prometheus + Grafana).

The goal is to move beyond system metrics (JVM, HTTP, DB) and provide **application-specific insights** such as redirect behavior, cache efficiency, and error tracking.

---

#### 1. Centralized Metrics Component

* Added `RapidLinkMetrics` class
* Responsible for:

  * registering all counters, timers, and gauges
  * providing a clean API for recording events
* Ensures:

  * single registration at startup
  * no metric duplication
  * minimal runtime overhead

---

#### 2. Business Metrics Coverage

##### 🔹 Redirect Metrics

* `rapidlink.redirect.success`
* `rapidlink.redirect.not_found`
* `rapidlink.redirect.expired`

##### 🔹 Cache Metrics

* `rapidlink.cache.hit`
* `rapidlink.cache.miss`
* `rapidlink.cache.negative.hit`

##### 🔹 URL Creation Metrics

* `rapidlink.url.create.success`
* `rapidlink.url.create.failure`

##### 🔹 Click Tracking

* `rapidlink.click.increment`
* `rapidlink.click.flush.db` (for future async batching)

##### 🔹 Error Metrics (Tagged)

* `rapidlink.error{type="db_error"}`
* `rapidlink.error{type="redis_unavailable"}`
* `rapidlink.error{type="unexpected"}`

##### 🔹 Latency Tracking

* `rapidlink.url.create.latency`
* `rapidlink.redirect.latency`

Includes percentile tracking (p50, p95, p99) for performance analysis.

---

####  4. Integration Points

##### 🔸 ShortUrlService

* URL creation latency tracking
* URL creation success/failure tracking
* redirect latency tracking
* redirect success tracking
* click increment tracking

##### 🔸 UrlCacheService

* Redis failure tracking 
* cache hit/miss tracking
* negative cache tracking 

##### 🔸 GlobalExceptionHandler

* DB errors → `db_error`
* Redis failures → `redis_unavailable`
* unexpected errors → `unexpected`

---

#### 5. Active URL Gauge

* `rapidlink.urls.active`
* Tracks number of active (non-expired) URLs
* ⚠️ Note: Currently updated synchronously; planned improvement to move to scheduled update

---

###  Testing

1. Start services (app + Prometheus + Grafana)
2. Hit endpoints:

   * `POST /shorten`
   * `GET /r/{shortCode}`
3. Check metrics:

   * `http://localhost:8080/actuator/prometheus`
4. Query in Prometheus:

   * `rate(rapidlink_redirect_success_total[1m])`
   * `rate(rapidlink_cache_hit_total[1m])`
   * etc
5. Visualize in Grafana dashboard




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive metrics across URL creation, resolution and caching (hits/misses, negative hits, clicks, active non-expired URL count)
  * Performance timing for URL creation and redirect operations

* **Improvements**
  * Enhanced monitoring of infrastructure failures (database and cache connectivity) with dedicated error metrics
  * More accurate tracking for not-found/expired/deactivated redirects and cache-negative sentinel hits
  * Unexpected errors now emit categorized metrics for observability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->